### PR TITLE
Allow Host Name Password Login

### DIFF
--- a/src/main/java/com/jcabi/ssh/SSHByPassword.java
+++ b/src/main/java/com/jcabi/ssh/SSHByPassword.java
@@ -87,7 +87,7 @@ public final class SSHByPassword implements Shell {
     public SSHByPassword(final String adr, final int prt,
         final String user, final String passwd)
         throws UnknownHostException {
-        this.addr = adr;
+        this.addr = InetAddress.getByName(adr).getHostAddress();
         Validate.matchesPattern(
             this.addr,
             "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",

--- a/src/main/java/com/jcabi/ssh/SSHByPassword.java
+++ b/src/main/java/com/jcabi/ssh/SSHByPassword.java
@@ -38,6 +38,7 @@ import com.jcraft.jsch.Session;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;


### PR DESCRIPTION
Changed a single line to be in line with the normal SSH class so that if
a host name is passed it gets converted to the IP Address instead of
throwing an exception.