### PR TITLE
Issue #28 - moving mock SSH server creation into separate module

### DIFF
--- a/src/test/java/com/jcabi/ssh/MockSshServerFactory.java
+++ b/src/test/java/com/jcabi/ssh/MockSshServerFactory.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2014-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.ssh;
+
+import com.google.common.io.Files;
+import java.io.File;
+import java.security.PublicKey;
+import java.util.Collections;
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.PublickeyAuthenticator;
+import org.apache.sshd.server.UserAuth;
+import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.mockito.Mockito;
+
+/**
+ * Factory creating mock SSH servers.
+ *
+ * @author Piotr Pradzynski (prondzyn@gmail.com)
+ * @version $Id$
+ * @since 1.6
+ * @checkstyle AbstractClassNameCheck (500 lines)
+ */
+final class MockSshServerFactory {
+
+    /**
+     * Utility class constructor.
+     */
+    private MockSshServerFactory() {
+        super();
+    }
+
+    /**
+     * Setup SSH server based on password authentication.
+     *
+     * @param port Port to listen on.
+     * @param login Login for an authentication.
+     * @param password Password for an authentication.
+     * @return SSH server.
+     */
+    public static SshServer passwordAuthenticatedServer(final int port,
+        final String login, final String password) {
+        final SshServer sshd = defaultServer(
+            port,
+            new UserAuthPassword.Factory()
+        );
+        final PasswordAuthenticator auth =
+            Mockito.mock(PasswordAuthenticator.class);
+        Mockito.when(
+            auth.authenticate(
+                Mockito.eq(login),
+                Mockito.eq(password),
+                Mockito.any(ServerSession.class)
+            )
+        ).thenReturn(true);
+        sshd.setPasswordAuthenticator(auth);
+        return sshd;
+    }
+
+    /**
+     * Setup SSH server based on public key authentication.
+     *
+     * @param port Port to listen on.
+     * @return SSH server.
+     */
+    public static SshServer publicKeyAuthenticatedServer(final int port) {
+        final SshServer sshd = defaultServer(
+            port,
+            new UserAuthPublicKey.Factory()
+        );
+        final PublickeyAuthenticator auth =
+            Mockito.mock(PublickeyAuthenticator.class);
+        Mockito.when(
+            auth.authenticate(
+                Mockito.anyString(),
+                Mockito.any(PublicKey.class),
+                Mockito.any(ServerSession.class)
+            )
+        ).thenReturn(true);
+        sshd.setPublickeyAuthenticator(auth);
+        return sshd;
+    }
+
+    /**
+     * Setup default SSH server.
+     *
+     * @param port Port to listen on.
+     * @param authfactory Authentication factory to use.
+     * @return SSH server.
+     */
+    private static SshServer defaultServer(final int port,
+        final NamedFactory<UserAuth> authfactory) {
+        final SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(port);
+        sshd.setKeyPairProvider(
+            new SimpleGeneratorHostKeyProvider(
+                new File(Files.createTempDir(), "hostkey.ser").getAbsolutePath()
+            )
+        );
+        sshd.setUserAuthFactories(
+            Collections.singletonList(authfactory)
+        );
+        return sshd;
+    }
+
+}

--- a/src/test/java/com/jcabi/ssh/SSHByPasswordTest.java
+++ b/src/test/java/com/jcabi/ssh/SSHByPasswordTest.java
@@ -54,18 +54,8 @@ import org.junit.Test;
  * @author Georgy Vlasov (wlasowegor@gmail.com)
  * @version $Id$
  * @since 1.4
- * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 public final class SSHByPasswordTest {
-    /**
-     * SSH login.
-     */
-    private static final String LOGIN = "test";
-
-    /**
-     * SSH password.
-     */
-    private static final String PASSWORD = "password";
 
     /**
      * Checks if {@link SSHByPassword} can execute a command on an SSH server.
@@ -73,9 +63,11 @@ public final class SSHByPasswordTest {
      */
     @Test
     public void executesCommand() throws Exception {
+        final String username = "test";
+        final String password = "password";
         final int port = SSHByPasswordTest.port();
         final SshServer sshd = new MockSshServerBuilder(port)
-            .usePasswordAuthentication(LOGIN, PASSWORD).build();
+            .usePasswordAuthentication(username, password).build();
         sshd.setCommandFactory(new SSHByPasswordTest.EchoCommandCreator());
         sshd.start();
         final String cmd = "some test command";
@@ -84,8 +76,8 @@ public final class SSHByPasswordTest {
             new SSHByPassword(
                 InetAddress.getLocalHost().getHostAddress(),
                 port,
-                LOGIN,
-                PASSWORD
+                username,
+                password
             )
         );
         final int exit = shell.exec(

--- a/src/test/java/com/jcabi/ssh/SSHByPasswordTest.java
+++ b/src/test/java/com/jcabi/ssh/SSHByPasswordTest.java
@@ -74,10 +74,8 @@ public final class SSHByPasswordTest {
     @Test
     public void executesCommand() throws Exception {
         final int port = SSHByPasswordTest.port();
-        final SshServer sshd =
-            MockSshServerFactory.passwordAuthenticatedServer(
-                port, LOGIN, PASSWORD
-            );
+        final SshServer sshd = new MockSshServerBuilder(port)
+            .usePasswordAuthentication(LOGIN, PASSWORD).build();
         sshd.setCommandFactory(new SSHByPasswordTest.EchoCommandCreator());
         sshd.start();
         final String cmd = "some test command";

--- a/src/test/java/com/jcabi/ssh/SSHTest.java
+++ b/src/test/java/com/jcabi/ssh/SSHTest.java
@@ -79,8 +79,8 @@ public final class SSHTest {
     @Test
     public void executeCommandOnServer() throws Exception {
         final int port = SSHTest.port();
-        final SshServer sshd =
-            MockSshServerFactory.publicKeyAuthenticatedServer(port);
+        final SshServer sshd = new MockSshServerBuilder(port)
+            .usePublicKeyAuthentication().build();
         sshd.setCommandFactory(new SSHTest.EchoCommandCreator());
         sshd.start();
         final String cmd = "some test command";

--- a/src/test/java/com/jcabi/ssh/SSHTest.java
+++ b/src/test/java/com/jcabi/ssh/SSHTest.java
@@ -29,35 +29,24 @@
  */
 package com.jcabi.ssh;
 
-import com.google.common.io.Files;
 import com.jcabi.log.Logger;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
-import java.security.PublicKey;
-import java.util.Collections;
 import java.util.logging.Level;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.sshd.SshServer;
-import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.server.Command;
 import org.apache.sshd.server.CommandFactory;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
-import org.apache.sshd.server.PublickeyAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPublicKey;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * Tests for ${@link SSH}.
@@ -90,7 +79,8 @@ public final class SSHTest {
     @Test
     public void executeCommandOnServer() throws Exception {
         final int port = SSHTest.port();
-        final SshServer sshd = SSHTest.server(port);
+        final SshServer sshd =
+            MockSshServerFactory.publicKeyAuthenticatedServer(port);
         sshd.setCommandFactory(new SSHTest.EchoCommandCreator());
         sshd.start();
         final String cmd = "some test command";
@@ -114,37 +104,6 @@ public final class SSHTest {
         sshd.stop();
         MatcherAssert.assertThat(exit, Matchers.equalTo(0));
         MatcherAssert.assertThat(output.toString(), Matchers.equalTo(cmd));
-    }
-
-    /**
-     * Setup SSH server.
-     * @param port Port to listen on.
-     * @return SSH server.
-     */
-    private static SshServer server(final int port) {
-        final SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(port);
-        final PublickeyAuthenticator auth =
-            Mockito.mock(PublickeyAuthenticator.class);
-        Mockito.when(
-            auth.authenticate(
-                Mockito.anyString(),
-                Mockito.any(PublicKey.class),
-                Mockito.any(ServerSession.class)
-            )
-        ).thenReturn(true);
-        sshd.setPublickeyAuthenticator(auth);
-        sshd.setUserAuthFactories(
-            Collections.<NamedFactory<UserAuth>>singletonList(
-                new UserAuthPublicKey.Factory()
-            )
-        );
-        sshd.setKeyPairProvider(
-            new SimpleGeneratorHostKeyProvider(
-                new File(Files.createTempDir(), "hostkey.ser").getAbsolutePath()
-            )
-        );
-        return sshd;
     }
 
     /**


### PR DESCRIPTION
I prepared a builder which provides unified place to prepare mocked SSH servers. Creating SSH servers in tests is now more readable. The builder is easily extendable for future functionality.