### PR TITLE
Removed todo puzzle

### DIFF
--- a/src/main/java/com/jcabi/ssh/SSH.java
+++ b/src/main/java/com/jcabi/ssh/SSH.java
@@ -183,7 +183,7 @@ public final class SSH extends AbstractSSHShell {
      */
     public SSH(final String adr, final int prt,
         final String user, final String priv) throws UnknownHostException {
-        this(adr, prt, user, priv, null);
+        this(adr, prt, user, priv, "");
     }
 
     /**
@@ -239,7 +239,7 @@ public final class SSH extends AbstractSSHShell {
                 CharEncoding.UTF_8
             );
             jsch.setHostKeyRepository(new EasyRepo());
-            if (this.passphrase == null) {
+            if (this.passphrase.isEmpty()) {
                 jsch.addIdentity(file.getAbsolutePath());
             } else {
                 jsch.addIdentity(

--- a/src/main/java/com/jcabi/ssh/SSH.java
+++ b/src/main/java/com/jcabi/ssh/SSH.java
@@ -183,7 +183,7 @@ public final class SSH extends AbstractSSHShell {
      */
     public SSH(final String adr, final int prt,
         final String user, final String priv) throws UnknownHostException {
-        this(adr, prt, user, priv, "");
+        this(adr, prt, user, priv, null);
     }
 
     /**
@@ -239,7 +239,7 @@ public final class SSH extends AbstractSSHShell {
                 CharEncoding.UTF_8
             );
             jsch.setHostKeyRepository(new EasyRepo());
-            if (this.passphrase.isEmpty()) {
+            if (this.passphrase == null) {
                 jsch.addIdentity(file.getAbsolutePath());
             } else {
                 jsch.addIdentity(

--- a/src/main/java/com/jcabi/ssh/SSH.java
+++ b/src/main/java/com/jcabi/ssh/SSH.java
@@ -69,9 +69,6 @@ import org.apache.commons.lang3.CharEncoding;
  * @version $Id$
  * @since 1.0
  * @see <a href="http://www.yegor256.com/2014/09/02/java-ssh-client.html">article by Yegor Bugayenko</a>
- * @todo #30:30min Refactor this class into smaller ones to avoid null
- *  checking of passphrase. There should probably be separate classes for
- *  encrypted/unencrypted private key.
  */
 @ToString
 @EqualsAndHashCode(of = { "key" }, callSuper = true)


### PR DESCRIPTION
This is for issue #50 
The puzzle suggests to take `SSH.key` and `SSH.passphrase` and wrap them in 2 different classes, for encrypted key/unencrypted key, thus refactoring method `SSH.session()`

However, I think this is a lot of change for too little gain. Not to mention, backwards compatibility goes to hell - this is supposed to be a simple-to-use ssh client, like the examples in the Javadoc.

If I make such changes, for starters the signatures change from `SSH(String, int, String, String, String)` to `SSH(String, int, PrivateKey)`, where `PrivateKey` is an interface implemented by `EncryptedKey` and `UnencryptedKey` (also the `username` would need to be passed to the `PrivateKey`, to use in the logic of creating the `jsch`. 

Then, we also have that `file` object (from method `SSH.session()`) which is supposed to be used only in the case of `UnencryptedKey`. However, the 2 classes need to respect the same interface, `PrivateKey` and while `UnencryptedKey` needs a public method to delete the file after `public jsch()` is called, `EncryptedKey` does not need it.

Anyway, the real problem from my point of view is changing the interface with the outer clients, which will have to make code changes once they upgrade the version.

Of course, there is the option to keep the constructors of `SSH` with the same parameters and wrap them in `PrivateKey` inside, but then we haven't done anything since we still need to decide whether `passphrase` is null, in order to build the appropriate `PrivateKey`. 

@ Reviewer - Please let me know what you think :D 
