### PR TITLE
Upgrade dependencies and qulice plugin to latest stable versions

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.44</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -77,18 +77,18 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.57.0</version>
+      <version>0.60.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.5.0-jre</version>
+      <version>33.6.0-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>2.27.9</version>
+      <version>2.28.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -167,7 +167,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.26.0</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>findbugs:.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.40.1</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-ssh</artifactId>
   <version>2.0-SNAPSHOT</version>

--- a/src/main/java/com/jcabi/ssh/AbstractSshShell.java
+++ b/src/main/java/com/jcabi/ssh/AbstractSshShell.java
@@ -47,6 +47,7 @@ abstract class AbstractSshShell implements Shell {
         final String adr,
         final int prt,
         final String user) throws UnknownHostException {
+        // @checkstyle ConstructorsCodeFreeCheck (1 line)
         this.addr = InetAddress.getByName(adr).getHostAddress();
         this.port = prt;
         this.login = user;
@@ -95,6 +96,5 @@ abstract class AbstractSshShell implements Shell {
      * @return JSch session
      * @throws IOException If some IO problem inside
      */
-    protected abstract Session session()  throws IOException;
-
+    protected abstract Session session() throws IOException;
 }

--- a/src/main/java/com/jcabi/ssh/EasyRepo.java
+++ b/src/main/java/com/jcabi/ssh/EasyRepo.java
@@ -54,5 +54,4 @@ final class EasyRepo implements HostKeyRepository {
     public HostKey[] getHostKey(final String host, final String type) {
         return new HostKey[0];
     }
-
 }

--- a/src/main/java/com/jcabi/ssh/Execution.java
+++ b/src/main/java/com/jcabi/ssh/Execution.java
@@ -68,6 +68,7 @@ final class Execution {
      * @return Return code of the command.
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public int exec() throws IOException {
         try {
             final ChannelExec channel = ChannelExec.class.cast(

--- a/src/main/java/com/jcabi/ssh/JschLogger.java
+++ b/src/main/java/com/jcabi/ssh/JschLogger.java
@@ -35,5 +35,4 @@ final class JschLogger implements com.jcraft.jsch.Logger {
         }
         Logger.log(jul, Ssh.class, msg);
     }
-
 }

--- a/src/main/java/com/jcabi/ssh/Shell.java
+++ b/src/main/java/com/jcabi/ssh/Shell.java
@@ -92,6 +92,7 @@ public interface Shell {
          * @param err Stderr to return
          */
         public Fake(final int exit, final String out, final String err) {
+            // @checkstyle ConstructorsCodeFreeCheck (4 lines)
             this(
                 exit,
                 out.getBytes(StandardCharsets.UTF_8),
@@ -106,6 +107,7 @@ public interface Shell {
          * @param err Stderr to return
          */
         public Fake(final int exit, final byte[] out, final byte[] err) {
+            // @checkstyle ConstructorsCodeFreeCheck (3 lines)
             this.code = exit;
             this.stdout = copyArray(out);
             this.stderr = copyArray(err);

--- a/src/main/java/com/jcabi/ssh/Ssh.java
+++ b/src/main/java/com/jcabi/ssh/Ssh.java
@@ -123,6 +123,7 @@ public final class Ssh extends AbstractSshShell {
      */
     public Ssh(final InetAddress adr, final String user, final String priv)
         throws UnknownHostException {
+        // @checkstyle ConstructorsCodeFreeCheck (1 line)
         this(adr.getCanonicalHostName(), Ssh.PORT, user, priv);
     }
 
@@ -138,6 +139,7 @@ public final class Ssh extends AbstractSshShell {
      */
     public Ssh(final String adr, final int prt,
         final String user, final URL priv) throws IOException {
+        // @checkstyle ConstructorsCodeFreeCheck (1 line)
         this(adr, prt, user, new UncheckedText(new TextOf(priv)).asString());
     }
 
@@ -153,6 +155,7 @@ public final class Ssh extends AbstractSshShell {
      */
     public Ssh(final InetAddress adr, final int prt,
         final String user, final URL priv) throws IOException {
+        // @checkstyle ConstructorsCodeFreeCheck (4 lines)
         this(
             adr.getCanonicalHostName(), prt, user,
             new UncheckedText(new TextOf(priv)).asString()
@@ -219,6 +222,7 @@ public final class Ssh extends AbstractSshShell {
             new Unchecked<>(
                 new LengthOf(
                     new TeeInput(
+                        // @checkstyle ProhibitLineSeparatorInStringsCheck (3 lines)
                         this.key.replaceAll("\r", "")
                             .replaceAll("\n\\s+|\n{2,}", "\n")
                             .trim(),

--- a/src/test/java/com/jcabi/ssh/MkCommand.java
+++ b/src/test/java/com/jcabi/ssh/MkCommand.java
@@ -83,5 +83,4 @@ final class MkCommand implements Command {
         Logger.debug(this, "#destroy(): finishing '%s'", this.command);
         session.close();
     }
-
 }

--- a/src/test/java/com/jcabi/ssh/MockSshServerBuilder.java
+++ b/src/test/java/com/jcabi/ssh/MockSshServerBuilder.java
@@ -53,6 +53,7 @@ class MockSshServerBuilder {
      * @param prt The port number for SSH server
      */
     MockSshServerBuilder(final int prt) {
+        // @checkstyle ConstructorsCodeFreeCheck (4 lines)
         this.port = prt;
         this.factories = new ArrayList<>(2);
         this.pwd = Optional.absent();
@@ -64,6 +65,7 @@ class MockSshServerBuilder {
      * @return SSH server.
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public SshServer build() throws IOException {
         final SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(this.port);
@@ -87,6 +89,7 @@ class MockSshServerBuilder {
      * @param password Password for an authentication.
      * @return This instance of builder.
      */
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public MockSshServerBuilder usePasswordAuthentication(
         final String login, final String password) {
         this.factories.add(new UserAuthPasswordFactory());
@@ -108,6 +111,7 @@ class MockSshServerBuilder {
      *
      * @return This instance of builder.
      */
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public MockSshServerBuilder usePublicKeyAuthentication() {
         this.factories.add(new UserAuthPublicKeyFactory());
         final PublickeyAuthenticator auth =
@@ -122,5 +126,4 @@ class MockSshServerBuilder {
         this.pkey = Optional.of(auth);
         return this;
     }
-
 }

--- a/src/test/java/com/jcabi/ssh/SshITCaseTemplate.java
+++ b/src/test/java/com/jcabi/ssh/SshITCaseTemplate.java
@@ -31,6 +31,7 @@ abstract class SshITCaseTemplate {
      * @return The shell
      * @throws Exception If fails
      */
+    @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public abstract Shell shell() throws Exception;
 
     @Test
@@ -125,5 +126,4 @@ abstract class SshITCaseTemplate {
         MatcherAssert.assertThat("should be 0", exit, Matchers.is(0));
         return stdout.toString(StandardCharsets.UTF_8);
     }
-
 }

--- a/src/test/java/com/jcabi/ssh/SshTest.java
+++ b/src/test/java/com/jcabi/ssh/SshTest.java
@@ -28,6 +28,7 @@ final class SshTest {
 
     @Test
     void escapesArgument() {
+        // @checkstyle ProhibitLineSeparatorInStringsCheck (5 lines)
         MatcherAssert.assertThat(
             "should equal to ''hi,\n '\\''$1'\\'''",
             Ssh.escape("hi,\n '$1'"),


### PR DESCRIPTION
@yegor256 - this PR is ready for review and merge. It bundles the open Renovate dependency upgrades into a single change, resolves the qulice 0.26.0 violations they expose, and unwedges the `(macos-15, java 11)` matrix cell that has been red on master for over a month.

The full workflow set runs green on my fork (all 6 mvn matrix cells, plus all linters): https://github.com/bibonix/jcabi-ssh/actions/runs/24931133237 (codecov on the fork is red only because the fork has no `CODECOV_TOKEN` secret - the underlying `mvn install -Pjacoco` step is green).

The upstream workflows here show `action_required` (first-time-fork policy). Please click "Approve and run workflows" so the matrix can run on this PR, then it should be ready to merge.

## Dependency upgrades

| Dependency | From | To |
| --- | --- | --- |
| `com.jcabi:jcabi` (parent) | 1.40.1 | 1.44.0 |
| `org.projectlombok:lombok` | 1.18.44 | 1.18.46 |
| `org.cactoos:cactoos` | 0.57.0 | 0.60.0 |
| `com.google.guava:guava` | 33.5.0-jre | 33.6.0-jre |
| `com.github.mwiede:jsch` | 2.27.9 | 2.28.0 |
| `org.testcontainers:testcontainers` | 2.0.3 | 2.0.5 |
| `com.qulice:qulice-maven-plugin` | 0.25.1 | 0.26.0 |

All are the latest stable versions on Maven Central. Stale alphas/milestones (`slf4j` 2.1.0-alpha1, `apache.sshd` 3.0.0-M3) were intentionally skipped.

## Qulice 0.26.0 fixes (29 violations)

Resolved in-place rather than excluded:

- `RegexpMultilineCheck` (Empty line before closing brace) - removed the blank line between the last method body and the class brace in `EasyRepo`, `JschLogger`, `AbstractSshShell`, `MkCommand`, `MockSshServerBuilder`, `SshITCaseTemplate`.
- `SingleSpaceSeparatorCheck` - collapsed the double space in `AbstractSshShell.session()`.
- `ConstructorsCodeFreeCheck` - added targeted `// @checkstyle ConstructorsCodeFreeCheck` suppressions on constructor delegations and field initialisations where the method call is intrinsic (`Optional.absent()`, `adr.getCanonicalHostName()`, decoding a `URL` to a `String`, `String.getBytes(UTF_8)`, defensive `copyArray`, `InetAddress.getByName(adr).getHostAddress()`).
- `ProhibitLineSeparatorInStringsCheck` - suppressed in `Ssh.session()` where `\r` and `\n` are required as regex tokens, and in `SshTest.escapesArgument()` where the literal `\n` is the value under test.
- PMD `PublicMemberInNonPublicType` - annotated the public methods of the package-private builders/templates (`Execution.exec`, `MockSshServerBuilder.{build,usePasswordAuthentication,usePublicKeyAuthentication}`, `SshITCaseTemplate.shell`) with `@SuppressWarnings("PMD.PublicMemberInNonPublicType")`. Their public surface is intentional - these classes form a fluent API used by callers in the same package.

## Workflow change

`mvn.yml` matrix changed from `java: [11, 17]` to `java: [17, 21]`.

The `(macos-15, java 11)` cell has been failing for >1 month with:

```
UnsupportedClassVersionError: com/qulice/maven/CheckMojo has been
compiled by a more recent version of the Java Runtime
(class file version 61.0)
```

`qulice-maven-plugin` was already on 0.25.1 (compiled to class file version 61.0 = Java 17) before this PR, so the Java 11 cell could never have been green. The bump to qulice 0.26.0 keeps the Java 17+ requirement. Dropping Java 11 and adding Java 21 brings the matrix in line with peer projects (`jcabi-urn`, `tojos`, ...).

## Verification

- Local `mvn --errors --batch-mode clean install -Pqulice` is green on JDK 21 and JDK 17.
- All 6 mvn matrix cells (Linux/macOS/Windows x JDK 17/21) pass on the fork.

## Supersedes

Once this lands the following individual Renovate PRs can be closed:
#309, #308, #307, #306, #303, #302, #293.
