### PR TITLE
Upgrade jsch to 2.28.2 and qulice plugin to 0.27.6

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>2.28.0</version>
+      <version>2.28.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>
@@ -167,7 +167,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.26.0</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>findbugs:.*</exclude>

--- a/src/main/java/com/jcabi/ssh/AbstractSshShell.java
+++ b/src/main/java/com/jcabi/ssh/AbstractSshShell.java
@@ -38,10 +38,10 @@ abstract class AbstractSshShell implements Shell {
 
     /**
      * Constructor.
-     * @param adr Address that you want to connect to.
-     * @param prt Port that you want to reach.
-     * @param user User that will be used when connecting.
-     * @throws UnknownHostException when host is unknown.
+     * @param adr Address that you want to connect to
+     * @param prt Port that you want to reach
+     * @param user User that will be used when connecting
+     * @throws UnknownHostException when host is unknown
      */
     AbstractSshShell(
         final String adr,

--- a/src/main/java/com/jcabi/ssh/EasyRepo.java
+++ b/src/main/java/com/jcabi/ssh/EasyRepo.java
@@ -12,7 +12,6 @@ import lombok.ToString;
 
 /**
  * Host key repository that accepts all hosts.
- *
  * @since 1.4
  */
 @ToString

--- a/src/main/java/com/jcabi/ssh/Execution.java
+++ b/src/main/java/com/jcabi/ssh/Execution.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
  * @since 1.4
  */
 final class Execution {
+
     /**
      * Command.
      */
@@ -65,7 +66,7 @@ final class Execution {
 
     /**
      * Executes some command.
-     * @return Return code of the command.
+     * @return Return code of the command
      * @throws IOException If fails
      */
     @SuppressWarnings("PMD.PublicMemberInNonPublicType")
@@ -127,7 +128,7 @@ final class Execution {
             } catch (final InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 throw new IOException(
-                    String.format(
+                    Logger.format(
                         "Interrupted after %[ms]s of waiting",
                         System.currentTimeMillis() - start
                     ),

--- a/src/main/java/com/jcabi/ssh/JschLogger.java
+++ b/src/main/java/com/jcabi/ssh/JschLogger.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 
 /**
  * Jsch Logger.
- *
  * @since 1.4
  */
 @ToString

--- a/src/main/java/com/jcabi/ssh/Shell.java
+++ b/src/main/java/com/jcabi/ssh/Shell.java
@@ -63,6 +63,7 @@ public interface Shell {
     @ToString
     @EqualsAndHashCode(of = "code")
     final class Fake implements Shell {
+
         /**
          * Exit code.
          */
@@ -141,13 +142,13 @@ public interface Shell {
 
     /**
      * Safe run (throws if exit code is not zero).
-     *
      * @since 0.1
      */
     @Immutable
     @ToString
     @EqualsAndHashCode(of = "origin")
     final class Safe implements Shell {
+
         /**
          * Original.
          */
@@ -178,13 +179,13 @@ public interface Shell {
 
     /**
      * Without input and output.
-     *
      * @since 0.1
      */
     @Immutable
     @ToString
     @EqualsAndHashCode(of = "origin")
     final class Empty {
+
         /**
          * Original.
          */
@@ -215,13 +216,13 @@ public interface Shell {
 
     /**
      * With output only.
-     *
      * @since 0.1
      */
     @Immutable
     @ToString
     @EqualsAndHashCode(of = "origin")
     final class Plain {
+
         /**
          * Original.
          */
@@ -247,19 +248,19 @@ public interface Shell {
                 cmd, new DeadInput().stream(),
                 baos, baos
             );
-            return baos.toString(StandardCharsets.UTF_8.toString());
+            return baos.toString(StandardCharsets.UTF_8);
         }
     }
 
     /**
      * Verbose run.
-     *
      * @since 0.1
      */
     @Immutable
     @ToString
     @EqualsAndHashCode(of = "orgn")
     final class Verbose implements Shell {
+
         /**
          * Original.
          */

--- a/src/main/java/com/jcabi/ssh/SshByPassword.java
+++ b/src/main/java/com/jcabi/ssh/SshByPassword.java
@@ -11,6 +11,7 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -67,7 +68,7 @@ public final class SshByPassword extends AbstractSshShell {
                 this.getLogin(), this.getAddr(), this.getPort()
             );
             session.setConfig("StrictHostKeyChecking", "no");
-            session.setPassword(this.password);
+            session.setPassword(this.password.getBytes(StandardCharsets.UTF_8));
             session.setServerAliveInterval(
                 (int) TimeUnit.SECONDS.toMillis(10)
             );

--- a/src/test/java/com/jcabi/ssh/MkCommand.java
+++ b/src/test/java/com/jcabi/ssh/MkCommand.java
@@ -22,6 +22,7 @@ import org.cactoos.scalar.Unchecked;
  * @since 1.6
  */
 final class MkCommand implements Command {
+
     /**
      * Command being executed.
      */
@@ -39,7 +40,7 @@ final class MkCommand implements Command {
 
     /**
      * Constructor.
-     * @param cmd Command to echo.
+     * @param cmd Command to echo
      */
     MkCommand(final String cmd) {
         this.command = cmd;

--- a/src/test/java/com/jcabi/ssh/MkCommandFactory.java
+++ b/src/test/java/com/jcabi/ssh/MkCommandFactory.java
@@ -11,10 +11,10 @@ import org.apache.sshd.server.command.CommandFactory;
 
 /**
  * Factory for command.
- *
  * @since 1.6
  */
 final class MkCommandFactory implements CommandFactory {
+
     @Override
     public Command createCommand(
         final ChannelSession session, final String cmd) {

--- a/src/test/java/com/jcabi/ssh/MockSshServerBuilder.java
+++ b/src/test/java/com/jcabi/ssh/MockSshServerBuilder.java
@@ -23,7 +23,6 @@ import org.mockito.Mockito;
 
 /**
  * Builder creating mock SSH servers.
- *
  * @since 1.6
  */
 class MockSshServerBuilder {
@@ -62,7 +61,7 @@ class MockSshServerBuilder {
 
     /**
      * Builds a new instance of SSH server.
-     * @return SSH server.
+     * @return SSH server
      * @throws IOException If fails
      */
     @SuppressWarnings("PMD.PublicMemberInNonPublicType")
@@ -84,10 +83,9 @@ class MockSshServerBuilder {
 
     /**
      * Setup a password authentication.
-     *
-     * @param login Login for an authentication.
-     * @param password Password for an authentication.
-     * @return This instance of builder.
+     * @param login Login for an authentication
+     * @param password Password for an authentication
+     * @return This instance of builder
      */
     @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public MockSshServerBuilder usePasswordAuthentication(
@@ -108,8 +106,7 @@ class MockSshServerBuilder {
 
     /**
      * Setup a public key authentication.
-     *
-     * @return This instance of builder.
+     * @return This instance of builder
      */
     @SuppressWarnings("PMD.PublicMemberInNonPublicType")
     public MockSshServerBuilder usePublicKeyAuthentication() {

--- a/src/test/java/com/jcabi/ssh/SshByPasswordITCase.java
+++ b/src/test/java/com/jcabi/ssh/SshByPasswordITCase.java
@@ -12,7 +12,6 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Integration test for ${@link Ssh}, which connects to
  * a real SSHD server over the Internet.
- *
  * @since 1.0
  */
 @Testcontainers(disabledWithoutDocker = true)
@@ -24,7 +23,7 @@ final class SshByPasswordITCase extends SshITCaseTemplate {
     @Container
     private final GenericContainer<?> sshd = new GenericContainer<>(
         DockerImageName.parse("linuxserver/openssh-server")
-    )
+        )
         .withEnv("USER_NAME", "jeff")
         .withEnv("USER_PASSWORD", "secret")
         .withEnv("PASSWORD_ACCESS", "true")

--- a/src/test/java/com/jcabi/ssh/SshByPasswordTest.java
+++ b/src/test/java/com/jcabi/ssh/SshByPasswordTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link SshByPassword}.
- *
  * @since 1.4
  */
 final class SshByPasswordTest {
@@ -61,8 +60,8 @@ final class SshByPasswordTest {
 
     /**
      * Allocate free port.
-     * @return Found port.
-     * @throws IOException In case of error.
+     * @return Found port
+     * @throws IOException In case of error
      */
     private static int port() throws IOException {
         final int port;

--- a/src/test/java/com/jcabi/ssh/SshITCase.java
+++ b/src/test/java/com/jcabi/ssh/SshITCase.java
@@ -18,7 +18,6 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Integration test for ${@link Ssh}, which connects to
  * a real SSHD server over the Internet.
- *
  * @since 1.0
  */
 @Testcontainers(disabledWithoutDocker = true)
@@ -37,7 +36,7 @@ final class SshITCase extends SshITCaseTemplate {
     @SuppressWarnings("PMD.AvoidDirectAccessToStaticFields")
     private final GenericContainer<?> sshd = new GenericContainer<>(
         DockerImageName.parse("linuxserver/openssh-server")
-    )
+        )
         .withEnv("USER_NAME", "jeff")
         .withEnv("PASSWORD_ACCESS", "false")
         .withEnv("PUBLIC_KEY", new TextOf(keys.resolve("rsa.pub")).toString())
@@ -59,7 +58,7 @@ final class SshITCase extends SshITCaseTemplate {
 
     /**
      * Generate key pair.
-     * @throws Exception If fails.
+     * @throws Exception If fails
      */
     @BeforeAll
     static void setUp() throws Exception {

--- a/src/test/java/com/jcabi/ssh/SshITCaseTemplate.java
+++ b/src/test/java/com/jcabi/ssh/SshITCaseTemplate.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Integration test for ${@link Ssh}, which connects to
  * a real SSHD server.
- *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (1000 lines)
  */

--- a/src/test/java/com/jcabi/ssh/SshTest.java
+++ b/src/test/java/com/jcabi/ssh/SshTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ${@link Ssh}.
- *
  * @since 1.0
  */
 final class SshTest {
@@ -115,8 +114,8 @@ final class SshTest {
 
     /**
      * Allocate free port.
-     * @return Found port.
-     * @throws IOException In case of error.
+     * @return Found port
+     * @throws IOException In case of error
      */
     private static int port() throws IOException {
         final int port;

--- a/src/test/java/com/jcabi/ssh/package-info.java
+++ b/src/test/java/com/jcabi/ssh/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * SSH client, tests.
- *
  * @since 1.0
  */
 package com.jcabi.ssh;


### PR DESCRIPTION
@yegor256 this PR upgrades two dependencies to their latest stable versions, fixes the resulting build issues, and aligns the CI matrix with what the new qulice plugin requires. All CI checks are green and it is ready for merge.

### Dependency upgrades
- `com.github.mwiede:jsch` 2.28.0 → 2.28.2
- `com.qulice:qulice-maven-plugin` 0.26.0 → 0.27.6

### Code fixes required by the upgrades
- `SshByPassword`: `Session.setPassword(String)` is deprecated in jsch 2.28.x in favor of `Session.setPassword(byte[])`. Migrated to the byte-array variant using UTF-8 encoding to preserve the previous behavior.
- `Shell.Plain`: replaced `ByteArrayOutputStream.toString(String)` with `toString(Charset)`, fixing an Error Prone `JdkObsolete` violation surfaced by qulice 0.27.6.
- `Execution`: replaced `String.format("... %[ms]s ...", ...)` with `Logger.format(...)`. The `%[ms]s` specifier is jcabi-log specific; calling `String.format` with it was a latent bug (Error Prone `FormatString`) that qulice 0.27.6 now catches.
- Several javadoc and formatting fixes in `main`/`test` sources for the new checkstyle rules in qulice 0.27.6 (`JavadocTagsDot`, `JavadocEmptyLineBeforeTag`, `EmptyLineBeforeFirstMember`, `CascadeIndentation`).

### Workflow change
- Dropped Java 17 from the `mvn` workflow matrix. qulice 0.27.6 is compiled with class-file version 65 (Java 21), so the plugin cannot be loaded on Java 17. The Java 21 only matrix matches qulice's own CI and the convention used in newer jcabi repositories such as jcabi-urn.

### Verification
- `mvn clean install` — green locally on JDK 21
- `mvn -Pqulice clean verify` — green locally on JDK 21 (the testcontainers ITs are skipped without Docker, same as before)
- All required CI checks are green on this PR (mvn ubuntu/macos/windows × Java 21, plus actionlint, codacy, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint).